### PR TITLE
Run Transform from Command line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,24 @@
 FROM atlas/analysisbase:latest
 
-LABEL maintainer Ilija Vukotic <ivukotic@cern.ch>
 
-# analysisbase already sets user "atlas" so have to sudo everything
+# analysisbase already sets user "atlas" so all these yum will have to do sudo.
+# but analysisbase seems to be very old sl6. we better move away from it.
 
-RUN sudo mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir 
-
-# needed to get x509 proxy to read the data
-RUN sudo yum -y update
-
-# this is for  centos7 but analysisbase is sl6
-
+# # needed to get x509 proxy to read the data
+# RUN yum -y update
 # RUN yum localinstall https://repo.opensciencegrid.org/osg/3.4/osg-3.4-el7-release-latest.rpm -y
+
 # RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; \
 #     curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg; \
-#     curl -s -o /etc/yum.repos.d/wlcg-centos7.repo http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo; 
+#     curl -s -o /etc/yum.repos.d/wlcg-centos7.repo http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo;
 
-RUN sudo yum localinstall https://repo.opensciencegrid.org/osg/3.4/osg-3.4-el6-release-latest.rpm -y
+# RUN yum install -y voms fetch-crl
+# ENV X509_USER_PROXY /etc/grid-security/x509up
 
-# epel comes preinstalled.
-# RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm;
 
-RUN sudo yum install -y voms fetch-crl 
-ENV X509_USER_PROXY /etc/grid-security/x509up
+COPY xaod_branches.* /home/atlas/
+COPY run_x509_updater.sh /home/atlas
+COPY transform_starter.py /home/atlas
 
-# not needed. 
-# RUN sudo yum install -y python34; \
-#     sudo curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; \
-#     sudo python3 get-pip.py; \
-#     sudo pip3 install elasticsearch;
-
-# get back to atlas user
-# RUN sudo su atlas
-
-# Create app directory
-WORKDIR /usr/src/app
-
-COPY . .
-
-# COPY run_x509_updater.sh /.
-# COPY transform_starter.py /.
-# COPY printXaodBranches.* /
-
-# CMD printXaodBranches.sh
+COPY printXaodBranches.* /home/atlas/
+ENTRYPOINT ["/home/atlas/xaod_branches.sh"]

--- a/README.md
+++ b/README.md
@@ -7,18 +7,27 @@ ATLAS analysis release. This is based a Docker image found here:
 # How to Build
 Build the docker image as:
 ```bash
-docker build -t printxaodbranches .
+docker build -t servicex_transform .
 ```
 
 # How to Run
-The script in the image assumes that there is a file available in the
-`/xaodFiles` directory called `AOD.11182705._000001.pool.root.1`. We will mount
-this directory in the running container.
+The script assumes that there is a mounted docker volume under `/data` - it will
+read ROOT files from this directory and output the flattened n-tuple file as
+well as the list of branches in this directory.
 
+The script accepts a number of command line arguments:
+
+| Argument | Description | Default |
+| -------- | ----------- | ------- |
+| f        | Path to ROOT File | None |
+| b        | Branch name | Electrons |
+| a        | List of attributes to read | _pt, eta, phi, e_0 |
+
+You can invoke the script from the command line as:
 ```bash
-docker run -v <<path to my xaod files>>:/xaodFiles printxaodbranches
+docker run --rm -v <<path to my xaod files>>:/data servicex_transform <<args>>
 ```
 
-The CMD for this Dockerfile will run the script which will output the
-branch names from the Root file.
- 
+When complete, your flattned Root file will be in the mounted directory with
+the name `flat_file.root` and all of the branches will be listed in a file
+called `xaodBranches.txt`

--- a/xaod_branches.py
+++ b/xaod_branches.py
@@ -11,7 +11,7 @@ def print_branches(file_name, branch_name):
     file_in = ROOT.TFile.Open(file_name)
     tree_in = ROOT.xAOD.MakeTransientTree(file_in)
 
-    ROOT.gSystem.RedirectOutput('temp.txt', 'w')
+    ROOT.gSystem.RedirectOutput('/data/temp.txt', 'w')
     tree_in.Print()
 
     # To print the attributes of a particle collection

--- a/xaod_branches.py
+++ b/xaod_branches.py
@@ -21,7 +21,7 @@ def print_branches(file_name, branch_name):
     if particles.size() >= 1:
         for method_name in dir(particles.at(0)):
             print(method_name)
-    
+
     ROOT.gROOT.ProcessLine("gSystem->RedirectOutput(0);")
 
 
@@ -29,18 +29,18 @@ def print_branches(file_name, branch_name):
 def write_branches_to_ntuple(file_name, branch_name, attr_name_list):
     sw = ROOT.TStopwatch()
     sw.Start()
-    
+
     file_in = ROOT.TFile.Open(file_name)
     tree_in = ROOT.xAOD.MakeTransientTree(file_in)
 
     tree_in.SetBranchStatus('*', 0)
     tree_in.SetBranchStatus('EventInfo', 1)
     tree_in.SetBranchStatus(branch_name, 1)
-    
+
     n_entries = tree_in.GetEntries()
     print("Total entries: " + str(n_entries))
 
-    file_out = ROOT.TFile('flat_file.root', 'recreate')
+    file_out = ROOT.TFile('/data/flat_file.root', 'recreate')
     tree_out = ROOT.TTree('flat_tree', '')
 
     n_particles = np.zeros(1, dtype=int)
@@ -71,13 +71,13 @@ def write_branches_to_ntuple(file_name, branch_name, attr_name_list):
             # if exec("type(particle." + attr_name + "())") == float:
             for attr_name in attr_name_list:
                 exec("particle_attr[attr_name].push_back(particle." + attr_name + "())")
-        
+
         tree_out.Fill()
 
     file_out.Write()
     file_out.Close()
     ROOT.xAOD.ClearTransientTrees()
-    
+
     sw.Stop()
     print("Real time: " + str(round(sw.RealTime() / 60.0, 2)) + " minutes")
     print("CPU time:  " + str(round(sw.CpuTime() / 60.0, 2)) + " minutes")

--- a/xaod_branches.sh
+++ b/xaod_branches.sh
@@ -2,6 +2,7 @@
 # Filename: xaod_branches.sh
 
 # Set up the environment
+PYTHONPATH=/
 source /home/atlas/release_setup.sh
 # echo '{gROOT->Macro("$ROOTCOREDIR/scripts/load_packages.C");}' > rootlogon.C
 
@@ -31,7 +32,7 @@ fi
 print_branches () {
     # Print xAOD branches to temporary file temp.txt
     python -c "import xaod_branches; xaod_branches.print_branches(\"$file\", \"$branch\")"
-    
+
     # Search the file for the branch name, type, and size
     >| xaodBranches.txt
     while read line; do
@@ -43,7 +44,7 @@ print_branches () {
             if [[ ! -z "$(echo \"$line\" | awk '{print $6}')" ]]; then
                 type="$type$(echo \"$line\" | awk '{print $5}')"
             fi
-        
+
             read nextLine
             if [[ "$nextLine" == *"|"* ]]; then
                 type="$type$(echo \"$nextLine\" | awk '{print $3}')"
@@ -71,7 +72,7 @@ print_branches () {
     done < temp.txt
 
     rm temp.txt
-    
+
     # Do whatever needs to be done with the output json
 }
 
@@ -85,7 +86,7 @@ write_branches_to_ntuple () {
     attr_list="${attr_list}]"
 
     python -c "import xaod_branches; xaod_branches.write_branches_to_ntuple(\"$file\", \"$branch\", $attr_list)"
-    
+
     # Do whatever needs to be done with the output flat ntuple
 }
 

--- a/xaod_branches.sh
+++ b/xaod_branches.sh
@@ -62,16 +62,16 @@ print_branches () {
         fi
 
         if [[ ! -z $name ]]; then
-            echo "{" >> xaodBranches.txt
-            echo "    \"branchName\": \"$name\"," >> xaodBranches.txt
-            echo "    \"branchType\": \"$type\"," >> xaodBranches.txt
-            echo "    \"branchSize\": $size" >> xaodBranches.txt
-            echo "}" >> xaodBranches.txt
+            echo "{" >> /data/xaodBranches.txt
+            echo "    \"branchName\": \"$name\"," >> /data/xaodBranches.txt
+            echo "    \"branchType\": \"$type\"," >> /data/xaodBranches.txt
+            echo "    \"branchSize\": $size" >> /data/xaodBranches.txt
+            echo "}" >> /data/xaodBranches.txt
             # echo "$name $type $size" >> xaodBranches.txt
         fi
-    done < temp.txt
+    done < /data/temp.txt
 
-    rm temp.txt
+    rm /data/temp.txt
 
     # Do whatever needs to be done with the output json
 }


### PR DESCRIPTION
# Problem:
The flattener code requires user to launch bash shell inside container and issue commands to 
transform a file. Users should be able to control the operation from their own command line and just launch a docker container to do all of the work, interacting with a mounted docker volume
Fixes: #8 

# Approach
Updated the `Dockerfiles` to copy all of the scripts into the image. Modified the scripts to read and write from the mounted docker volume at `/data`

# How to Test
Build a docker image from the new code:
```bash
docker build -t servicex_transform .
```

Then run the code 
```bash
docker run --rm -v <<path to my xaod files>>:/data servicex_transform -f /data//data/AOD.11182705._000001.pool.root.1 -b Muons
```

