### PR TITLE
Extend branch configuration

### DIFF
--- a/xaod_branches.sh
+++ b/xaod_branches.sh
@@ -2,7 +2,6 @@
 # Filename: xaod_branches.sh
 
 # Set up the environment
-PYTHONPATH=/
 source /home/atlas/release_setup.sh
 # echo '{gROOT->Macro("$ROOTCOREDIR/scripts/load_packages.C");}' > rootlogon.C
 
@@ -24,7 +23,7 @@ if [[ -z $branch ]]; then
     branch="Electrons"
 fi
 if [[ -z $attr_array ]]; then
-    attr_array=("pt" "eta" "phi" "e")
+    attr_array=("Electrons.pt()" "Electrons.eta()" "Electrons.phi()" "Electrons.e()")
 fi
 
 
@@ -32,9 +31,9 @@ fi
 print_branches () {
     # Print xAOD branches to temporary file temp.txt
     python -c "import xaod_branches; xaod_branches.print_branches(\"$file\", \"$branch\")"
-
+    
     # Search the file for the branch name, type, and size
-    >| xaodBranches.txt
+    >| xaod_branches.txt
     while read line; do
         name=""
         type=""
@@ -44,7 +43,7 @@ print_branches () {
             if [[ ! -z "$(echo \"$line\" | awk '{print $6}')" ]]; then
                 type="$type$(echo \"$line\" | awk '{print $5}')"
             fi
-
+        
             read nextLine
             if [[ "$nextLine" == *"|"* ]]; then
                 type="$type$(echo \"$nextLine\" | awk '{print $3}')"
@@ -62,17 +61,17 @@ print_branches () {
         fi
 
         if [[ ! -z $name ]]; then
-            echo "{" >> /data/xaodBranches.txt
-            echo "    \"branchName\": \"$name\"," >> /data/xaodBranches.txt
-            echo "    \"branchType\": \"$type\"," >> /data/xaodBranches.txt
-            echo "    \"branchSize\": $size" >> /data/xaodBranches.txt
-            echo "}" >> /data/xaodBranches.txt
-            # echo "$name $type $size" >> xaodBranches.txt
+            echo "{" >> xaod_branches.txt
+            echo "    \"branchName\": \"$name\"," >> xaod_branches.txt
+            echo "    \"branchType\": \"$type\"," >> xaod_branches.txt
+            echo "    \"branchSize\": $size" >> xaod_branches.txt
+            echo "}" >> xaod_branches.txt
+            # echo "$name $type $size" >> xaod_branches.txt
         fi
-    done < /data/temp.txt
+    done < temp.txt
 
-    rm /data/temp.txt
-
+    rm temp.txt
+    
     # Do whatever needs to be done with the output json
 }
 
@@ -85,8 +84,8 @@ write_branches_to_ntuple () {
     done
     attr_list="${attr_list}]"
 
-    python -c "import xaod_branches; xaod_branches.write_branches_to_ntuple(\"$file\", \"$branch\", $attr_list)"
-
+    python -c "import xaod_branches; xaod_branches.write_branches_to_ntuple(\"$file\", $attr_list)"
+    
     # Do whatever needs to be done with the output flat ntuple
 }
 


### PR DESCRIPTION
User can now specify branch attributes directly (e.g. "Electrons.pt(), Electrons.eta()") as input arguments. The code loads the corresponding branch (e.g. "Electrons") and creates an ntuple with the associated attributes ("Electrons_pt", "Electrons_eta")