### PR TITLE
Use public kafka brokers and increase chunk size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 secrets
+.idea/
+__pycache__/
+

--- a/xaod_branches.py
+++ b/xaod_branches.py
@@ -11,8 +11,13 @@ from kafka import KafkaProducer
 # import uproot_methods
 
 ROOT.gROOT.Macro('$ROOTCOREDIR/scripts/load_packages.C')
-kafka_brokers = ['servicex-kafka.kafka.svc.cluster.local:9092']
-chunk_size = 500
+kafka_brokers = ['servicex-kafka-0.slateci.net:19092',
+                 'servicex-kafka-1.slateci.net:19092',
+                 'servicex-kafka-2.slateci.net:19092']
+
+# How many events to include in each Kafka message. This needs to be small
+# enough to keep below the broker and consumer max bytes
+chunk_size = 5000
 
 
 


### PR DESCRIPTION
Fixes #16 
# Problem 
The hardcoded Kafka Brokers in the transformer script refer to the private Kafka cluster. We need to start writing to the public broker so the analysis cluster can read the messages.

Also, a chunk size of 500 makes for very small messages indeed. Increase this to improve the system efficiency.
