### PR TITLE
Command Line Control over Transformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 secrets
 .idea/
 __pycache__/
+*.pyc
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,14 +39,12 @@ ENV X509_USER_PROXY /etc/grid-security/x509up
 # Create app directory
 WORKDIR /usr/src/app
 
+
+# Update atlas user's startup script to always initialize the Atlas release
+COPY bashrc /home/atlas/.bashrc
+COPY requirements.txt .
+RUN source /home/atlas/release_setup.sh; \
+    pip install --user -r requirements.txt
+
 COPY . .
 
-RUN source /home/atlas/release_setup.sh; \
-    pip install --user \
-    awkward==0.10.2 \
-    requests \
-    pyarrow \
-    kafka \
-    confluent_kafka \
-    redis \
-    pympler

--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,9 @@
+# .bashrc
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+        . /etc/bashrc
+fi
+
+# Initialize the Atlas software release
+source /home/atlas/release_setup.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+awkward==0.10.2
+requests
+pyarrow
+kafka
+confluent_kafka
+redis
+pympler

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/servicex/servicex_adaptor.py
+++ b/servicex/servicex_adaptor.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import requests
+
+
+class ServiceX:
+    def __init__(self, endpoint):
+        self.endpoint = endpoint
+
+    def _servicex(self, path):
+        return self.endpoint+path
+
+    def get_transform_requests(self):
+        rpath_output = requests.get(
+            self._servicex('/dpath/transform'),
+            verify=False)
+
+        if rpath_output.text == 'false':
+            return None
+        else:
+            return rpath_output.json()
+
+    def get_request_info(self, request_id):
+        request_output = requests.get(
+            self._servicex('/drequest/' + request_id),
+            verify=False)
+        return request_output.json()
+
+    def update_request_events_served(self, request_id, num_events):
+        requests.put(self._servicex('/drequest/events_served/' + request_id +
+                     '/' + str(num_events)), verify=False)
+
+    def update_path_events_served(self, path_id, num_events):
+        requests.put(self._servicex('/dpath/events_served/' + path_id +
+                     '/' + str(num_events)), verify=False)
+
+    def post_validated_status(self, path_id):
+        requests.put(self._servicex('/dpath/status/' + path_id + '/Validated'),
+                     verify=False)
+
+    def post_transformed_status(self, path_id):
+        requests.put(self._servicex('/dpath/status/' + path_id + '/Transformed'),
+                     verify=False)
+
+
+
+
+
+

--- a/servicex/transformer/__init__.py
+++ b/servicex/transformer/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/servicex/transformer/kafka_messaging.py
+++ b/servicex/transformer/kafka_messaging.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import sys
+import os
+import time
+from messaging import Messaging
+from kafka import KafkaProducer
+
+
+class KafkaMessaging(Messaging):
+    def __init__(self, brokers):
+
+        self.MAX_MESSAGES_PER_REQUEST = 100
+        if 'MAX_MESSAGES_PER_REQUEST' in os.environ:
+            self.MAX_MESSAGES_PER_REQUEST = int(os.environ['MAX_MESSAGES_PER_REQUEST'])
+        print("max messages per request:", self.MAX_MESSAGES_PER_REQUEST)
+
+        if not brokers:
+            self.brokers = ['servicex-kafka-0.slateci.net:19092',
+                            'servicex-kafka-1.slateci.net:19092',
+                            'servicex-kafka-2.slateci.net:19092']
+        else:
+            self.brokers = brokers
+
+        self.producer = None
+        print('Configured Kafka backend')
+
+        try:
+            self.producer = KafkaProducer(bootstrap_servers=self.brokers,
+                                          api_version=(0, 10))
+            print("Kafka producer created successfully")
+        except Exception as ex:
+            print("Exception while getting Kafka producer", ex)
+            sys.exit(1)
+
+    def publish_message(self, topic_name, key, value_buffer):
+        try:
+            while True:
+                self.set_kafka_producer()
+                if self.producer:
+                    print('Kafka producer connected.')
+                    break
+                print('waiting to connect kafka producer...')
+                time.sleep(60)
+            self.producer.send(topic_name, key=str(key),
+                               value=value_buffer.to_pybytes())
+            self.producer.flush()
+            print("Message published successfully")
+        except Exception as ex:
+            print("Exception in publishing message", ex)
+            raise
+

--- a/servicex/transformer/kafka_messaging.py
+++ b/servicex/transformer/kafka_messaging.py
@@ -60,13 +60,6 @@ class KafkaMessaging(Messaging):
 
     def publish_message(self, topic_name, key, value_buffer):
         try:
-            while True:
-                self.set_kafka_producer()
-                if self.producer:
-                    print('Kafka producer connected.')
-                    break
-                print('waiting to connect kafka producer...')
-                time.sleep(60)
             self.producer.send(topic_name, key=str(key),
                                value=value_buffer.to_pybytes())
             self.producer.flush()
@@ -74,4 +67,5 @@ class KafkaMessaging(Messaging):
         except Exception as ex:
             print("Exception in publishing message", ex)
             raise
+        return True
 

--- a/servicex/transformer/messaging.py
+++ b/servicex/transformer/messaging.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from abc import ABCMeta, abstractmethod
+
+
+class Messaging:
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def publish_message(self, topic_name, key, value_buffer):
+        pass

--- a/servicex/transformer/redis_messaging.py
+++ b/servicex/transformer/redis_messaging.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import os
+import time
+import redis
+import codecs
+
+
+class Messaging:
+    def __init__(self, host='redis.slateci.net', port=6379):
+
+        self.MAX_MESSAGES_PER_REQUEST = 100
+        if 'MAX_MESSAGES_PER_REQUEST' in os.environ:
+            self.MAX_MESSAGES_PER_REQUEST = int(os.environ['MAX_MESSAGES_PER_REQUEST'])
+        print("max messages per request:", self.MAX_MESSAGES_PER_REQUEST)
+        self.host = host
+        self.port = port
+        self.client = None
+
+        print('Configured Redis backend')
+
+    def set_redis_client(self):
+        self.client = redis.Redis(self.host, self.port, db=0)
+
+    def publish_message(self, topic_name, key, value_buffer):
+        # connect if not already done
+        try:
+            while True:
+                if self.client:
+                    # print('Redis client connected.')
+                    break
+                self.set_redis_client()
+                print('waiting to connect redis client...')
+                time.sleep(60)
+        except Exception as ex:
+            print("Exception in publishing message:", ex)
+            raise
+        request_id = 'req_id:' + topic_name
+        # check if queue is still full, if yes return false.
+        if self.client.xlen(request_id) > self.MAX_MESSAGES_PER_REQUEST:
+            return False
+
+        # add message
+        self.client.xadd(request_id, {'pa': key, 'data': codecs.encode(value_buffer, 'bz2')})
+        return True
+
+    def request_status_redis(self, topic_name):
+        try:
+            topic_name = 'req_id:' + topic_name
+            request_info = self.client.xinfo_stream(topic_name)
+            print('req_info:', request_info)
+        except redis.exceptions.ResponseError as redis_e:
+            print(redis_e)

--- a/servicex/transformer/redis_messaging.py
+++ b/servicex/transformer/redis_messaging.py
@@ -31,7 +31,7 @@ import redis
 import codecs
 
 
-class Messaging:
+class RedisMessaging:
     def __init__(self, host='redis.slateci.net', port=6379):
 
         self.MAX_MESSAGES_PER_REQUEST = 100

--- a/xaod_branches.py
+++ b/xaod_branches.py
@@ -11,7 +11,7 @@ import pyarrow as pa
 import awkward
 import requests
 import time
-import messaging
+from servicex.transformer.kafka_messaging import KafkaMessaging
 # import uproot_methods
 
 ROOT.gROOT.Macro('$ROOTCOREDIR/scripts/load_packages.C')
@@ -26,7 +26,9 @@ if 'WAIT_FOR_CONSUMER' in os.environ:
     wait_for_consumer = int(os.environ['WAIT_FOR_CONSUMER'])
 print("seconds waiting for consumer to restart:", wait_for_consumer)
 
-m = messaging.Messaging()
+m = KafkaMessaging(['servicex-kafka-0.slateci.net:19092',
+                    'servicex-kafka-1.slateci.net:19092',
+                    'servicex-kafka-2.slateci.net:19092'])
 
 
 def make_event_table(tree, branches, f_evt, l_evt):


### PR DESCRIPTION
# Problem
The transformer code is difficult to test and do performance evaluation since it is deeply embedded in the serviceX infrastructure. We need to be able to easily run single files or launch an analyzer job on a user's desktop.

# Approach
1. Added argparse to the `xaod_branches` script to make it easier to configure 
2. Refactored the messaging class into two subclasses to make the code easier to manage. Added command line options `-kafka` and `-redis` to switch between implementations
3. Factored the serviceX REST interactions into a class and made the calls optional so the transformer can run without sending messages to ServiceX
4. The layers in the Dockerfile were not laid out in a way that allowed for quick builds when just python code changes are made. Cleaned that up and extracted the dependencies into a requirements.txt file