### PR TITLE
Read ROOT files from DID-Finder output file

### DIFF
--- a/servicex/transformer/kafka_messaging.py
+++ b/servicex/transformer/kafka_messaging.py
@@ -60,10 +60,11 @@ class KafkaMessaging(Messaging):
 
     def publish_message(self, topic_name, key, value_buffer):
         try:
+            bytes = value_buffer.to_pybytes()
             self.producer.send(topic_name, key=str(key),
-                               value=value_buffer.to_pybytes())
+                               value=bytes)
             self.producer.flush()
-            print("Message published successfully")
+            print("Message published successfully ", len(bytes))
         except Exception as ex:
             print("Exception in publishing message", ex)
             raise


### PR DESCRIPTION
# Problem 
Command line testing of analyzer only works on one file at a time.

# Approach
Add command line option to read a dataset file produced by DID Finder

Also, fix bug with return value from `servicex.get_request_info` call