### PR TITLE
Add heuristic to guess at chunk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ each backend.
 | --servicex SERVICEX_ENDPOINT | Endpoint for servicex REST API | servicex.slateci.net  |
 | --dataset DATASET | Path to JSON Dataset document from DID Finder with collection of ROOT Files to process | |
 | --path PATH | Path to single Root file to transform | |
-| --chunks CHUNKS | Number of events to include in each message | 50,000 |
+| --max-message-size | Maximum size for any message in Megabytes | 14.5 Mb |
+| --chunks CHUNKS | Number of events to include in each message. If ommitted, it will compute a best guess based on heuristics and max message size | None |
 | --attrs ATTR_NAMES | List of attributes to extract | Electrons.pt(), Electrons.eta(), Electrons.phi(), Electrons.e()|
 | --limit LIMIT | Max number of events to process | |
 | --wait WAIT | Number of seconds to wait for consumer to restart | 600 seconds|

--- a/servicex/transformer/kafka_messaging.py
+++ b/servicex/transformer/kafka_messaging.py
@@ -33,12 +33,9 @@ from kafka import KafkaProducer
 
 
 class KafkaMessaging(Messaging):
-    def __init__(self, brokers):
+    def __init__(self, brokers, max_message_size=15):
 
-        self.MAX_MESSAGES_PER_REQUEST = 100
-        if 'MAX_MESSAGES_PER_REQUEST' in os.environ:
-            self.MAX_MESSAGES_PER_REQUEST = int(os.environ['MAX_MESSAGES_PER_REQUEST'])
-        print("max messages per request:", self.MAX_MESSAGES_PER_REQUEST)
+        print("Max Message size: " + str(max_message_size) + "Mb")
 
         if not brokers:
             self.brokers = ['servicex-kafka-0.slateci.net:19092',
@@ -52,7 +49,8 @@ class KafkaMessaging(Messaging):
 
         try:
             self.producer = KafkaProducer(bootstrap_servers=self.brokers,
-                                          api_version=(0, 10))
+                                          api_version=(0, 10),
+                                          max_request_size=int(max_message_size * 1e6))
             print("Kafka producer created successfully")
         except Exception as ex:
             print("Exception while getting Kafka producer", ex)
@@ -64,7 +62,7 @@ class KafkaMessaging(Messaging):
             self.producer.send(topic_name, key=str(key),
                                value=bytes)
             self.producer.flush()
-            print("Message published successfully ", len(bytes))
+            print("Message published to ", topic_name, " successfully ", len(bytes))
         except Exception as ex:
             print("Exception in publishing message", ex)
             raise


### PR DESCRIPTION
The correct chunk size for messages depends on the number of columns in the request. This is a simple approach where we use an estimate of size per column per event to try to fill the message, but not overmuch.

Added a new parameter --max-message-size which states the largest number of Mb to include in the message. We try to get as close to this as possible without going over