### PR TITLE
Deadletter Queue

### DIFF
--- a/xaod_branches.py
+++ b/xaod_branches.py
@@ -172,6 +172,23 @@ def put_file_complete(endpoint, file_path, status, num_messages=None,
         })
 
 
+def put_file_failed(endpoint, file_path, status, num_messages=None, total_time=None):
+    doc = {
+        "file-path": file_path,
+        "status": status,
+        "num-messages": num_messages,
+        "total-time": total_time
+    }
+    print("------< ", doc)
+    if endpoint:
+        requests.put(endpoint+"/file-failed", json={
+            "file-path": file_path,
+            "status": status,
+            "num-messages": num_messages,
+            "total-time": total_time
+        })
+
+
 def write_branches_to_arrow(messaging, topic_name, file_path, servicex_id, attr_name_list,
                             chunk_size, server_endpoint, event_limit=None,
                             object_store=None):
@@ -213,9 +230,9 @@ def write_branches_to_arrow(messaging, topic_name, file_path, servicex_id, attr_
                       "Avg Cell Size = " + str(avg_cell_size) + " bytes")
                 batch_number += 1
 
-                if server_endpoint:
-                    post_status_update(server_endpoint, "Processed " +
-                                       str(batch.num_rows))
+                # if server_endpoint:
+                #     post_status_update(server_endpoint, "Processed " +
+                #                        str(batch.num_rows))
 
     if object_store:
         _close_scratch_file(args.result_format, scratch_writer)
@@ -266,6 +283,7 @@ def callback(channel, method, properties, body):
         channel.basic_publish(exchange='transformation_failures',
                               routing_key=_request_id + '_errors',
                               body=json.dumps(transform_request))
+        put_file_failed(_server_endpoint, _file_path, "failure", 0, 0.0)
     finally:
         channel.basic_ack(delivery_tag=method.delivery_tag)
 

--- a/xaod_branches.py
+++ b/xaod_branches.py
@@ -255,7 +255,6 @@ def callback(channel, method, properties, body):
     columns = list(map(lambda b: b.strip(),
                        transform_request['columns'].split(",")))
 
-
     print(_file_path)
     try:
         write_branches_to_arrow(messaging=messaging, topic_name=_request_id,

--- a/xaod_branches.py
+++ b/xaod_branches.py
@@ -172,23 +172,6 @@ def put_file_complete(endpoint, file_path, status, num_messages=None,
         })
 
 
-def put_file_failed(endpoint, file_path, status, num_messages=None, total_time=None):
-    doc = {
-        "file-path": file_path,
-        "status": status,
-        "num-messages": num_messages,
-        "total-time": total_time
-    }
-    print("------< ", doc)
-    if endpoint:
-        requests.put(endpoint+"/file-failed", json={
-            "file-path": file_path,
-            "status": status,
-            "num-messages": num_messages,
-            "total-time": total_time
-        })
-
-
 def write_branches_to_arrow(messaging, topic_name, file_path, servicex_id, attr_name_list,
                             chunk_size, server_endpoint, event_limit=None,
                             object_store=None):
@@ -283,7 +266,7 @@ def callback(channel, method, properties, body):
         channel.basic_publish(exchange='transformation_failures',
                               routing_key=_request_id + '_errors',
                               body=json.dumps(transform_request))
-        put_file_failed(_server_endpoint, _file_path, "failure", 0, 0.0)
+        put_file_complete(_server_endpoint, _file_path, "failure", 0, 0.0)
     finally:
         channel.basic_ack(delivery_tag=method.delivery_tag)
 


### PR DESCRIPTION
# Problem
Failures during transformation cause the transformer to crash and the file gets put back on the queue. Need to trap these exceptions and safely put the message on a dead letter queue.

Partial solution for serviceX [issue 23](https://github.com/ssl-hep/ServiceX/issues/23)

# Approach
1. Wrap the transformer code in try/except block
2. Add code in the except block to format an error message and place it on the dead letter queue
3. Move the ack to the `finally` block
4. Add a call to `file-complete` endpoint to record skipped file
