### PR TITLE
Add full transformer loggings

### DIFF
--- a/servicex/transformer/xaod_transformer.py
+++ b/servicex/transformer/xaod_transformer.py
@@ -36,8 +36,22 @@ class XAODTransformer:
     def arrow_table(self, chunk_size, event_limit=sys.maxint):
 
         def group(iterator, n):
-            while True:
-                yield [iterator.next() for i in range(n)]
+            """
+            Batch together chunks of events into a single yield
+            :param iterator: Iterator from which events are drown
+            :param n: Number of events to include in each yield
+            :return: Yields a list of n or fewer events
+            """
+            done = False
+            while not done:
+                results = []
+                try:
+                    for i in range(n):
+                        results.append(iterator.next())
+                    yield results
+                except StopIteration:
+                    done = True
+                    yield results
 
         for events in group(self.event_iterator.iterate(event_limit), chunk_size):
             object_array = awkward.fromiter(events)


### PR DESCRIPTION
# Problem
Need to send logging messages to elastic search
Also discovered that files that had a final chunk less than chunk size didn't send the last message to Kafka

This is partial fulfillment of [ServiceX Issue #37](https://github.com/ssl-hep/ServiceX/issues/37)

# Approach
Fixed the generator function in `xaod_transformer.py` to yield the final results when the end of file is reached.

Added more details to the status messages sent to the app.

Deleted some unused code


