### PR TITLE
Make properly permissioned x509 proxy available to xrootd

### DIFF
--- a/proxy-exporter.sh
+++ b/proxy-exporter.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+sudo mkdir -p /etc/grid-security
+sudo chown atlas /etc/grid-security
+
+
+while true; do
+    sudo cp /etc/grid-security-ro/x509up /etc/grid-security
+    sudo chown atlas /etc/grid-security/x509up
+    chmod 600 /etc/grid-security/x509up
+
+    # Refresh every hour
+    sleep 3600
+
+done


### PR DESCRIPTION
Partial fix to ServiceX #57

Add a script that copies the X509 proxy from the secret, sets the correct ownership and permissions