### PR TITLE
Add detailed file-level logging

### DIFF
--- a/servicex/transformer/arrow_writer.py
+++ b/servicex/transformer/arrow_writer.py
@@ -31,10 +31,8 @@ import pyarrow as pa
 
 class ArrowWriter:
 
-    def __init__(self, file_format=None, servicex=None,
-                 object_store=None, messaging=None):
+    def __init__(self, file_format=None, object_store=None, messaging=None):
         self.file_format = file_format
-        self.servicex = servicex
         self.object_store = object_store
         self.messaging = messaging
 
@@ -99,14 +97,5 @@ class ArrowWriter:
 
             scratch_writer.remove_scratch_file()
 
-        if self.servicex:
-            self.servicex. post_status_update("File " + transformer.file_path + " complete")
-
         tock = time.time()
         print("Real time: " + str(round(tock - tick / 60.0, 2)) + " minutes")
-        if self.servicex:
-            self.servicex.put_file_complete(transformer.file_path, file_id, "success",
-                                            num_messages=batch_number,
-                                            total_time=round(tock - tick / 60.0, 2),
-                                            total_events=total_events,
-                                            total_bytes=total_bytes)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name='servicex-transformer',
     packages=setuptools.find_packages(),
-    version='0.4.0',
+    version='0.4.1',
     license='bsd 3 clause',
     description='ServiceX Data Transformer for HEP Data',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name='servicex-transformer',
     packages=setuptools.find_packages(),
-    version='0.3.0',
+    version='0.4.0',
     license='bsd 3 clause',
     description='ServiceX Data Transformer for HEP Data',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name='servicex-transformer',
     packages=setuptools.find_packages(),
-    version='0.4.1',
+    version='0.4.2',
     license='bsd 3 clause',
     description='ServiceX Data Transformer for HEP Data',
     long_description=long_description,
@@ -51,7 +51,8 @@ setuptools.setup(
         'numpy == 1.16.6',
         'kafka-python',
         'pika',
-        'minio '
+        'minio',
+        'retry == 0.9.2'
     ],
 
     extras_require={


### PR DESCRIPTION
# Problem 
Diagnosing some issues with Transformers can be difficult. The logs are spread across hundreds of pods. In the course of testing this out, discovered that status reports occasionally fail due to timeouts. 

# Approach
Add a file-level log statement that can show when the file transformer starts, retries, fails, or succeeds. Extract the Pod name from an environment variable and include it in the report

Removed logging from the ArrowWriter since this should be tackled in the calling transformer

Changed the configuration of `requests` library to enable retries