### PR TITLE
Add tracking of kafka and minio timings

### DIFF
--- a/servicex/transformer/arrow_writer.py
+++ b/servicex/transformer/arrow_writer.py
@@ -58,10 +58,11 @@ class ArrowWriter:
                 scratch_writer.append_table_to_scratch(pa_table)
 
             total_events = total_events + pa_table.num_rows
-            batches = pa_table.to_batches(max_chunksize=transformer.chunk_size)
 
-            for batch in batches:
-                if self.messaging:
+            if self.messaging:
+                batches = pa_table.to_batches(max_chunksize=transformer.chunk_size)
+
+                for batch in batches:
                     messaging_tick = time.time()
                     key = str.encode(transformer.file_path + "-" + str(batch_number))
 
@@ -84,10 +85,6 @@ class ArrowWriter:
                           "Avg Cell Size = " + str(avg_cell_size) + " bytes")
                     batch_number += 1
                     self.messaging_timings.append(time.time() - messaging_tick)
-
-                    # if server_endpoint:
-                    #     post_status_update(server_endpoint, "Processed " +
-                    #                        str(batch.num_rows))
 
         if self.object_store:
             object_store_tick = time.time()

--- a/servicex/transformer/kafka_messaging.py
+++ b/servicex/transformer/kafka_messaging.py
@@ -61,8 +61,6 @@ class KafkaMessaging(Messaging):
             self.producer.send(topic_name, key=key,
                                value=msg_bytes)
             self.producer.flush()
-            print("Message published to ", topic_name, " successfully ",
-                  len(msg_bytes))
         except Exception as ex:
             print("Exception in publishing message", ex)
             raise

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name='servicex-transformer',
     packages=setuptools.find_packages(),
-    version='0.4.2',
+    version='0.4.3',
     license='bsd 3 clause',
     description='ServiceX Data Transformer for HEP Data',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name='servicex-transformer',
     packages=setuptools.find_packages(),
-    version='0.4.3',
+    version='0.4.4.post1',
     license='bsd 3 clause',
     description='ServiceX Data Transformer for HEP Data',
     long_description=long_description,


### PR DESCRIPTION
# Problem
The ArrowWriter function does quite a bit and it's hard to see where the time is spent.

# Approach
Add two new properties to the class:
* messaging_timings
* object_store_timing

After the call to `write_branches_to_arrow` they can be interrogated to find out how many seconds each Kafka message took to commit and how long it took to write the root file to Minio