### PR TITLE
Add retry for rabbitMQ connection error

### DIFF
--- a/servicex/transformer/tests/test_rabbit_mq_manager.py
+++ b/servicex/transformer/tests/test_rabbit_mq_manager.py
@@ -25,6 +25,8 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import socket
+
 import pika
 
 from servicex.transformer.rabbit_mq_manager import RabbitMQManager
@@ -43,7 +45,9 @@ class TestRabbitMQManager:
         mock_conn = mocker.MagicMock(pika.BlockingConnection)
         mock_conn.channel = mocker.Mock(return_value=mock_channel)
 
-        mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_conn)
+        # First attempt to connect will fail, and then after retry succeed
+        mock_pika = mocker.patch('pika.BlockingConnection',
+                                 side_effect=[socket.gaierror(), mock_conn])
 
         RabbitMQManager("http:/foo.com", "servicex", callback)
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name='servicex-transformer',
     packages=setuptools.find_packages(),
-    version='1.0.0-RC.2',
+    version='1.0.0-RC.3',
     license='bsd 3 clause',
     description='ServiceX Data Transformer for HEP Data',
     long_description=long_description,


### PR DESCRIPTION
# Problem
If there is a temporary network issue in the cluster that prevents the transformer from connecting to the RabbitMQ broker, the transformer dies

Fixes serviceX [issue 26](https://github.com/ssl-hep/ServiceX/issues/226)
