### PR TITLE
Replace prints with logging setup

### DIFF
--- a/servicex/transformer/arrow_writer.py
+++ b/servicex/transformer/arrow_writer.py
@@ -31,26 +31,23 @@ import pyarrow as pa
 
 class ArrowWriter:
 
-    def __init__(self, file_format=None, object_store=None, messaging=None, logger=None):
+    def __init__(self, file_format=None, object_store=None, messaging=None):
         self.file_format = file_format
         self.object_store = object_store
         self.messaging = messaging
         self.messaging_timings = []
         self.object_store_timing = 0
         self.avg_cell_size = []
-        self.__init_logger(logger)
+        self.__init_logger()
 
-    def __init_logger(self, logger):
-        if not logger:
-            # Default logger outputs to console and writes time - name: message
-            import logging
-            formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
-            handler = logging.StreamHandler()
-            handler.setFormatter(formatter)
-            self.__logger = logging.getLogger(__name__)
-            self.__logger.addHandler(handler)
-        else:
-            self.__logger = logger
+    def __init_logger(self):
+        # Default logger doesn't print so that code that uses library
+        # can override
+        import logging
+
+        handler = logging.NullHandler()
+        self.__logger = logging.getLogger(__name__)
+        self.__logger.addHandler(handler)
 
     def write_branches_to_arrow(self, transformer,
                                 topic_name, file_id, request_id):

--- a/servicex/transformer/kafka_messaging.py
+++ b/servicex/transformer/kafka_messaging.py
@@ -31,17 +31,14 @@ from kafka import KafkaProducer
 
 
 class KafkaMessaging(Messaging):
-    def __init__(self, brokers, max_message_size=15, logger = None):
-        if not logger:
-            # Default logger outputs to console and writes time - name: message
-            import logging
-            formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
-            handler = logging.StreamHandler()
-            handler.setFormatter(formatter)
-            self.__logger = logging.getLogger(__name__)
-            self.__logger.addHandler(handler)
-        else:
-            self.__logger = logger
+    def __init__(self, brokers, max_message_size=15):
+        # Default logger doesn't print so that code that uses library
+        # can override
+        import logging
+
+        handler = logging.NullHandler()
+        self.__logger = logging.getLogger(__name__)
+        self.__logger.addHandler(handler)
 
         self.__logger.info(f"Max Message size: {str(max_message_size)} Mb")
         self.max_message_size = max_message_size

--- a/servicex/transformer/rabbit_mq_manager.py
+++ b/servicex/transformer/rabbit_mq_manager.py
@@ -33,8 +33,18 @@ import socket
 
 class RabbitMQManager:
 
-    def __init__(self, rabbit_uri, queue_name, callback):
+    def __init__(self, rabbit_uri, queue_name, callback, logger=None):
         success = False
+        if not logger:
+            # Default logger outputs to console and writes time - name: message
+            import logging
+            formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
+            self.__logger = logging.getLogger(__name__)
+            self.__logger.addHandler(handler)
+        else:
+            self.__logger = logger
         while not success:
             try:
                 self.rabbitmq = pika.BlockingConnection(
@@ -52,5 +62,5 @@ class RabbitMQManager:
                 _channel.start_consuming()
                 success = True
             except socket.gaierror:
-                print("Failed to connect to RabbitMQ Broker.... retrying")
+                self.__logger.error("Failed to connect to RabbitMQ Broker.... retrying")
                 sleep(10)

--- a/servicex/transformer/rabbit_mq_manager.py
+++ b/servicex/transformer/rabbit_mq_manager.py
@@ -33,18 +33,14 @@ import socket
 
 class RabbitMQManager:
 
-    def __init__(self, rabbit_uri, queue_name, callback, logger=None):
+    def __init__(self, rabbit_uri, queue_name, callback):
         success = False
-        if not logger:
-            # Default logger outputs to console and writes time - name: message
-            import logging
-            formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
-            handler = logging.StreamHandler()
-            handler.setFormatter(formatter)
-            self.__logger = logging.getLogger(__name__)
-            self.__logger.addHandler(handler)
-        else:
-            self.__logger = logger
+
+        import logging
+        handler = logging.NullHandler()
+        self.__logger = logging.getLogger(__name__)
+        self.__logger.addHandler(handler)
+
         while not success:
             try:
                 self.rabbitmq = pika.BlockingConnection(

--- a/servicex/transformer/servicex_adapter.py
+++ b/servicex/transformer/servicex_adapter.py
@@ -39,16 +39,13 @@ RETRY_DELAY = 2
 
 class ServiceXAdapter:
     def __init__(self, servicex_endpoint, logger=None):
-        if not logger:
-            # Default logger outputs to console and writes time - name: message
-            import logging
-            formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
-            handler = logging.StreamHandler()
-            handler.setFormatter(formatter)
-            self.__logger = logging.getLogger(__name__)
-            self.__logger.addHandler(handler)
-        else:
-            self.__logger = logger
+        # Default logger doesn't print so that code that uses library
+        # can override
+        import logging
+
+        handler = logging.NullHandler()
+        self.__logger = logging.getLogger(__name__)
+        self.__logger.addHandler(handler)
 
         self.server_endpoint = servicex_endpoint
         self.session = requests.session()

--- a/servicex/transformer/servicex_adapter.py
+++ b/servicex/transformer/servicex_adapter.py
@@ -38,7 +38,18 @@ RETRY_DELAY = 2
 
 
 class ServiceXAdapter:
-    def __init__(self, servicex_endpoint):
+    def __init__(self, servicex_endpoint, logger=None):
+        if not logger:
+            # Default logger outputs to console and writes time - name: message
+            import logging
+            formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
+            self.__logger = logging.getLogger(__name__)
+            self.__logger.addHandler(handler)
+        else:
+            self.__logger = logger
+
         self.server_endpoint = servicex_endpoint
         self.session = requests.session()
 
@@ -62,8 +73,8 @@ class ServiceXAdapter:
                        tries=MAX_RETRIES,
                        delay=RETRY_DELAY)
         except requests.exceptions.ConnectionError:
-            print("*************** Unrecoverable Error ***************")
-            print("Connection Error in post_status_update")
+            self.__logger.error("*************** Unrecoverable Error ***************")
+            self.__logger.error("Connection Error in post_status_update")
 
     def put_file_complete(self, file_path, file_id, status,
                           num_messages=None, total_time=None, total_events=None,
@@ -79,7 +90,7 @@ class ServiceXAdapter:
             "total-bytes": total_bytes,
             "avg-rate": avg_rate
         }
-        print("------< ", doc)
+        self.__logger.info(f"------< {doc}")
 
         if self.server_endpoint:
             try:
@@ -89,5 +100,5 @@ class ServiceXAdapter:
                            tries=MAX_RETRIES,
                            delay=RETRY_DELAY)
             except requests.exceptions.ConnectionError:
-                print("*************** Unrecoverable Error ***************")
-                print("Connection Error in put_file_complete")
+                self.__logger.error("*************** Unrecoverable Error ***************")
+                self.__logger.error("Connection Error in put_file_complete")


### PR DESCRIPTION
A strawman PR to replace print statements with logging output.  There's a few things that may need to be changed.  I added a logger arg to the init so that the default logger can be swapped out.  It's handy but it does alter the signature.  Also, the output format may need to be tweaked, @ivukotic  may want to check to make sure this is what he wanted.  Also, I wonder if the logging initialization should be pulled out to a utility library or a base class of some sort.  