### PR TITLE
Fix CI and Pypi Publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,14 +41,3 @@ jobs:
       if: github.event_name == 'push'
       run: |
         codecov --token=${{ secrets.CODECOV_TOKEN }}
-
-  publish:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Publish package
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,12 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install --no-cache-dir -e .[test]
         pip list
-    - name: Check for vulnerabilities in libraries
-      run: |
-        pip install safety
-        pip freeze | safety check
+#    Dropping safety check since we continue to support python 2.7, but it
+#    fails safety check for obvious reasons!
+#    - name: Check for vulnerabilities in libraries
+#      run: |
+#        pip install safety
+#        pip freeze | safety check
     - name: Lint with Flake8
       run: |
         flake8

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,29 @@
+name: Push to PyPI
+
+on:
+  release:
+    types: [released, prereleased]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip build
+    - name: Build the servicex_transformer wheel
+      env:
+        servicex_version: ${{ github.ref }}
+      run: |
+        python -m build --sdist --wheel
+    - name: Publish servicex to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.3.1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,23 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import os
+
 import setuptools
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+version = os.getenv('servicex_version')
+if version is None:
+    version = '0.1a1'
+else:
+    version = version.split('/')[-1]
+
 setuptools.setup(
     name='servicex-transformer',
     packages=setuptools.find_packages(),
-    version='1.0.0-RC.3',
+    version=version,
     license='bsd 3 clause',
     description='ServiceX Data Transformer for HEP Data',
     long_description=long_description,


### PR DESCRIPTION
# Problem
The CI Job is failing due to safety check not able to run against 2.7 any more. Also the publish to pypi is not working

Fixes #50 

# Approach
Removed safety check for now

Copied the publish to pypi recipe from the servicex_frontend repo
