### PR TITLE
Updated requirements to all latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,24 @@ setuptools.setup(
     url='https://github.com/ssl-hep/ServiceX_transformer',
     keywords=['HEP', 'Data Engineering', 'Data Lake'],
     install_requires=[
-        'uproot==4.1.9',
-        'awkward == 1.7.0',
-        'requests==2.28.1',
-        'pyarrow == 3.0.0',
-        'numpy == 1.23.3',
+        'uproot==3.11.7',
+        'awkward == 0.12.21',
+        'requests == 2.24.0',
+        'pyarrow == 0.16.0',
+        # 'numpy == 1.16.6',
+
+        # 'uproot==3.11.7',
+        # 'awkward == 0.12.21',
+        # 'requests == 2.24.0',
+        # 'pyarrow == 0.16.0',
+        'numpy == 1.18.1',
+
+        # 'uproot==4.1.9',
+        # 'awkward == 1.7.0',
+        # 'requests==2.28.1',
+        # 'pyarrow == 3.0.0',
+        # 'numpy == 1.23.3',
+
         'pika==1.1.0',
         'minio==7.1.12',
         'retry == 0.9.2'

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,11 @@ setuptools.setup(
 
         'uproot==4.3.7',
         'awkward==1.10.1',
+        'lz4',
+        'xxhash',
+        'zstandard',
+        'backports.lzma',
+        'xrootd',
         'pyarrow==9.0.0',
 
         'pika==1.1.0',

--- a/setup.py
+++ b/setup.py
@@ -53,16 +53,20 @@ setuptools.setup(
     keywords=['HEP', 'Data Engineering', 'Data Lake'],
     install_requires=[
         # 'awkward == 0.12.21',
-        'requests == 2.24.0',
-        'pyarrow == 0.16.0',
+        # 'requests == 2.24.0',
+        # 'pyarrow == 0.16.0',
         # 'numpy == 1.16.6',
-        'numpy == 1.18.1',
+        # 'numpy == 1.18.1',
 
-        'uproot==4.1.9',
-        'awkward == 1.7.0',
-        # 'requests==2.28.1',
+        # 'uproot==4.1.9',
+        # 'awkward == 1.7.0',
+        'requests==2.28.1',
         # 'pyarrow == 3.0.0',
         # 'numpy == 1.23.3',
+
+        'uproot==4.3.7',
+        'awkward==1.10.1',
+        'pyarrow==9.0.0',
 
         'pika==1.1.0',
         'minio==7.1.12',

--- a/setup.py
+++ b/setup.py
@@ -52,14 +52,14 @@ setuptools.setup(
     url='https://github.com/ssl-hep/ServiceX_transformer',
     keywords=['HEP', 'Data Engineering', 'Data Lake'],
     install_requires=[
-        'awkward == 0.12.21',
+        # 'awkward == 0.12.21',
         'requests == 2.24.0',
         'pyarrow == 0.16.0',
         # 'numpy == 1.16.6',
         'numpy == 1.18.1',
 
         'uproot==4.1.9',
-        # 'awkward == 1.7.0',
+        'awkward == 1.7.0',
         # 'requests==2.28.1',
         # 'pyarrow == 3.0.0',
         # 'numpy == 1.23.3',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
         'lz4',
         'xxhash',
         'zstandard',
-        'backports.lzma',
+        # 'backports.lzma',
         'xrootd',
         'pyarrow==9.0.0',
 

--- a/setup.py
+++ b/setup.py
@@ -52,19 +52,13 @@ setuptools.setup(
     url='https://github.com/ssl-hep/ServiceX_transformer',
     keywords=['HEP', 'Data Engineering', 'Data Lake'],
     install_requires=[
-        'uproot==3.11.7',
         'awkward == 0.12.21',
         'requests == 2.24.0',
         'pyarrow == 0.16.0',
         # 'numpy == 1.16.6',
-
-        # 'uproot==3.11.7',
-        # 'awkward == 0.12.21',
-        # 'requests == 2.24.0',
-        # 'pyarrow == 0.16.0',
         'numpy == 1.18.1',
 
-        # 'uproot==4.1.9',
+        'uproot==4.1.9',
         # 'awkward == 1.7.0',
         # 'requests==2.28.1',
         # 'pyarrow == 3.0.0',

--- a/setup.py
+++ b/setup.py
@@ -52,18 +52,7 @@ setuptools.setup(
     url='https://github.com/ssl-hep/ServiceX_transformer',
     keywords=['HEP', 'Data Engineering', 'Data Lake'],
     install_requires=[
-        # 'awkward == 0.12.21',
-        # 'requests == 2.24.0',
-        # 'pyarrow == 0.16.0',
-        # 'numpy == 1.16.6',
-        # 'numpy == 1.18.1',
-
-        # 'uproot==4.1.9',
-        # 'awkward == 1.7.0',
         'requests==2.28.1',
-        # 'pyarrow == 3.0.0',
-        # 'numpy == 1.23.3',
-
         'uproot==4.3.7',
         'awkward==1.10.1',
         'lz4',
@@ -72,7 +61,6 @@ setuptools.setup(
         # 'backports.lzma',
         'xrootd',
         'pyarrow==9.0.0',
-
         'pika==1.1.0',
         'minio==7.1.12',
         'retry == 0.9.2'


### PR DESCRIPTION
This is to be used only with the uproot transformer and was used for 1.0.7 release.
XAOD transformer has to stick to 1.0.6-rc3 until sidecar is ready. 